### PR TITLE
Fix clang-format call for macOS/Darwin

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,7 +2,7 @@
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
-	format_cmd="$clang_format -i -style=file '{}'"
+	format_cmd="clang-format -i -style=file '{}'"
 elif [[ "$unamestr" == 'Linux' ]]; then
 	format_cmd="clang-format-6.0 -i -style=file '{}'"
 fi


### PR DESCRIPTION
The clang_format variable was not defined in my environment, I assume the clang-format tool was intended to be used instead.